### PR TITLE
Adding the ability to stop background processes

### DIFF
--- a/src/Task/Base/Exec.php
+++ b/src/Task/Base/Exec.php
@@ -93,10 +93,14 @@ class Exec extends BaseTask implements CommandInterface, PrintedInterface
         $this->stop();
     }
 
-    protected function stop()
+    public function stop()
     {
         if ($this->background && $this->process->isRunning()) {
             $this->process->stop();
+
+            $key = array_search($this, static::$instances);
+            unset(self::$instances[$key]);
+
             $this->printTaskInfo("stopped <info>".$this->getCommand()."</info>");
         }
     }


### PR DESCRIPTION
This PR makes the ```stop()``` method on processes public. It also unsets the instance from the ```$instances``` static property when a process is stopped.

This addresses #131